### PR TITLE
Reduce asset update fee from $2 to $0.1

### DIFF
--- a/usd-denominated-fees/config.py
+++ b/usd-denominated-fees/config.py
@@ -2,9 +2,6 @@
 # To discuss for next schedule
 # ============================
 #
-#  * Reduction of asset_update fee if the CERs for UIA go out of sync
-#    too much ($2 per update might be too high)
-#  * Discuss asset_create fee
 #  * Percentage based vesting_withdraw?
 #
 #
@@ -548,19 +545,20 @@ native_fees = {  #####################################################
     #
     # Rational:
     #
-    #     * most assets will probably never need to change at all
-    #     * prediction market assets should change to be re-used after settlement
-    #     * Core Exchange rates for User-issued assets can
-    #       only be changed with this operation!
+    #     * asset owners have already paid a relately large amount to create
+    #       the assets
+    #     * asset owners rely on this operation to keep core exchange rate
+    #       and other parameters up-to-date, so the operation is expected
+    #       to be used rather frequently
     #
     # Conclusion:
     #
-    #     * Any fee between $0.50-$5 seems to be reasonable considering
+    #     * A fee between $0.05-$0.5 seems to be reasonable considering
     #       the above arguments.
     #     * Depending on the actual business model, a high fee might result in
-    #       CERs to go 'out-of sync' or   at least get updated more rarely
+    #       CERs to go 'out-of sync' or at least get updated more rarely
     #
-    "asset_update": {"fee": 2, "price_per_kbyte": 0.007},
+    "asset_update": {"fee": 0.1, "price_per_kbyte": 0.007},
     #####################################################
     #
     # Description:

--- a/usd-denominated-fees/config.py
+++ b/usd-denominated-fees/config.py
@@ -545,7 +545,7 @@ native_fees = {  #####################################################
     #
     # Rational:
     #
-    #     * asset owners have already paid a relately large amount to create
+    #     * asset owners have already paid a relatively large amount to create
     #       the assets
     #     * asset owners rely on this operation to keep core exchange rate
     #       and other parameters up-to-date, so the operation is expected


### PR DESCRIPTION
Rationale:
* asset owners have already paid a relatively large amount to create the assets
* asset owners rely on this operation to keep core exchange rate and other parameters up-to-date, so the operation is expected to be used rather frequently

Related discussion: https://bitsharestalk.org/index.php?topic=32410